### PR TITLE
Add optional time and illuminance conditions to motion sensor light blueprint

### DIFF
--- a/automations/motion-sensor-light-initial-state.yaml
+++ b/automations/motion-sensor-light-initial-state.yaml
@@ -1,36 +1,44 @@
 blueprint:
   name: Motion Sensor Light with Initial State Memory
-  description: > 
+  description: >
     ## Description
 
-    Turn on a light when motion is detected. When motion is no longer detected, the light is either turned off or is returned to 
-    its initial state.
+    Turn on a light when motion is detected. When motion is no longer detected,
+    the light is either turned off or is returned to its initial state.
 
-    If the "Wait time" value is set, the automation will wait the specified amount of seconds after motion is no longer detected
-    before returning the light to its previous state.
+    If the "Wait time" value is set, the automation will wait the specified
+    amount of seconds after motion is no longer detected before returning the
+    light to its previous state.
 
     ## Options
 
-      - Wait Time: If set, the automation will wait the specified amount of seconds after motion is no longer detected
-        before returning the light to its previous state. Setting this value to `0` will result in the light being immediately
-        turned off after motion stops.
-      
-      - State Memory: If enabled, the light is returned to its initial state when motion is no longer detected.
+      - Wait Time: If set, the automation will wait the specified amount of
+        seconds after motion is no longer detected before returning the light to
+        its previous state. Setting this value to `0` will result in the light
+        being immediately turned off after motion stops.
+
+      - State Memory: If enabled, the light is returned to its initial state
+        when motion is no longer detected.
 
     ## Use Case
 
-    The default Motion Activated Light blueprint included by default with Home Assistant operates such that the target light will
-    be turned off regardless of the state it was in at the time of motion starting. 
-    
-    Consider a scenario where you have a hallway night light that is normally enabled only when motion is detected. If you wished 
-    to leave the light on all night on some given day, and you were the default blueprint. If motion were detected at any point in
-    the night, the light would then be turned off after motion stops.
+    The default Motion Activated Light blueprint included by default with Home
+    Assistant operates such that the target light will be turned off regardless
+    of the state it was in at the time of motion starting.
 
-    By using this blueprint, you can choose to have the light return to its original state (i.e. on) when motion is no longer detected.
+    Consider a scenario where you have a hallway night light that is normally
+    enabled only when motion is detected. If you wished to leave the light on
+    all night on some given day, and you were the default blueprint. If motion
+    were detected at any point in the night, the light would then be turned off
+    after motion stops.
+
+    By using this blueprint, you can choose to have the light return to its
+    original state (i.e. on) when motion is no longer detected.
 
     ## State Memory Behaviour
 
-    The following table indicates the effect that state memory has on the light entity's state.
+    The following table indicates the effect that state memory has on the light
+    entity's state.
 
     - State Memory:`off`, Initial light state:`off` => State after motion stops:`off`
 
@@ -76,23 +84,72 @@ blueprint:
     timeout:
       name: Automation Timeout (Minutes)
       description: >
-        Amount of time for the automation to wait for motion to stop. If this is exceeded, the automation will abandon any state memory 
-        and wait to run again next time motion is detected.
+        Amount of time for the automation to wait for motion to stop. If this is
+        exceeded, the automation will abandon any state memory and wait to run
+        again next time motion is detected.
       default: 360
       selector:
         number:
           min: 0
           max: 1440
           unit_of_measurement: minutes
+    time_after:
+      name: Time After
+      description: Only activate after this time.
+      default: ""
+      selector:
+        time: {}
+    time_before:
+      name: Time Before
+      description: Only activate before this time.
+      default: ""
+      selector:
+        time: {}
+    illuminance_sensor:
+      name: Illuminance Sensor
+      description: Optional sensor to check lux levels.
+      default: ""
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+              device_class: illuminance
+    illuminance_threshold:
+      name: Illuminance Threshold
+      description: Only activate if illuminance is below this value.
+      default: 10
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: lx
 variables:
   light_entity: !input light_entity
   state_memory: !input state_memory
+  time_after: !input time_after
+  time_before: !input time_before
+  illuminance_sensor: !input illuminance_sensor
+  illuminance_threshold: !input illuminance_threshold
 triggers:
   - trigger: state
     entity_id:
       - !input motion_entity
     to: "on"
-conditions: []
+conditions:
+  - condition: template
+    value_template: >
+      {% if time_after == "" and time_before == "" %}
+        true
+      {% elif time_after != "" and time_before != "" and time_after > time_before %}
+        {{ now() >= today_at(time_after) or now() <= today_at(time_before) }}
+      {% else %}
+        {{ (time_after == "" or now() >= today_at(time_after)) and
+           (time_before == "" or now() <= today_at(time_before)) }}
+      {% endif %}
+  - condition: template
+    value_template: >
+      {{ illuminance_sensor == "" or states(illuminance_sensor) | float(0) <=
+         (illuminance_threshold | float) }}
 actions:
   - variables:
       initial_light_state: "{{ states(light_entity) | bool }}"
@@ -114,10 +171,10 @@ actions:
       - condition: not
         conditions:
           - and:
-            - condition: template
-              value_template: "{{ initial_light_state }}"
-            - condition: template
-              value_template: "{{ state_memory | bool }}"
+              - condition: template
+                value_template: "{{ initial_light_state }}"
+              - condition: template
+                value_template: "{{ state_memory | bool }}"
     then:
       - action: light.turn_off
         target:


### PR DESCRIPTION
Closes #2. This PR adds optional time windows and illuminance (lux) threshold conditions to the Motion Sensor Light with Initial State Memory blueprint. This allows users to restrict the automation to specific times of day or only when it is dark.